### PR TITLE
Fix Initial Select Value To Use ValueLink Value

### DIFF
--- a/dist/frig.js
+++ b/dist/frig.js
@@ -1854,7 +1854,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: "_setInitialValue",
 	    value: function _setInitialValue(nextProps) {
-	      var value = nextProps.options[0].value;
+	      var value = nextProps.valueLink.value || nextProps.options[0].value;
 
 	      nextProps.valueLink.requestChange(value, { setModified: false });
 	    }

--- a/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
+++ b/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
@@ -15,6 +15,7 @@ AccountForm = React.createClass
       password: "test"
       shareSketchyInfo: false
       addresses: [{address: "55 Actual Place Rd."}, {}]
+      select_example: "thing-value"
       stuff_or_things: ["stuff-value"]
       single_select_typeahead: "stuff-value"
 


### PR DESCRIPTION
Fix the initial of value for select to use the value in ValueLink  instead of the first value in order to always select what is the Frig form data first before doing to the first item to select.