### PR TITLE
Fix Initial Select Value To Use ValueLink Value

### DIFF
--- a/src/javascripts/components/value_linked_select.js
+++ b/src/javascripts/components/value_linked_select.js
@@ -48,7 +48,7 @@ export default class ValueLinkedSelect extends React.Component {
   }
 
   _setInitialValue(nextProps) {
-    let {value} = valueLink.value || nextProps.options[0]
+    let value = valueLink.value || nextProps.options[0].value
     nextProps.valueLink.requestChange(value, {setModified: false})
   }
 

--- a/src/javascripts/components/value_linked_select.js
+++ b/src/javascripts/components/value_linked_select.js
@@ -48,7 +48,7 @@ export default class ValueLinkedSelect extends React.Component {
   }
 
   _setInitialValue(nextProps) {
-    let {value} = nextProps.options[0]
+    let {value} = valueLink.value || nextProps.options[0]
     nextProps.valueLink.requestChange(value, {setModified: false})
   }
 


### PR DESCRIPTION
Sorry, I have added the fix for Select Value Link in the wrong file, so when a new update happen it ease my update. Add to the correct file.

Fix the initial of value for select to use the value in ValueLink instead of the first value in order to always select what is the Frig form data first before doing to the first item to select.