### PR TITLE
Add Missing nextProps In Textarea

### DIFF
--- a/src/javascripts/components/value_linked_select.js
+++ b/src/javascripts/components/value_linked_select.js
@@ -48,7 +48,7 @@ export default class ValueLinkedSelect extends React.Component {
   }
 
   _setInitialValue(nextProps) {
-    let value = valueLink.value || nextProps.options[0].value
+    let value = nextProps.valueLink.value || nextProps.options[0].value
     nextProps.valueLink.requestChange(value, {setModified: false})
   }
 


### PR DESCRIPTION
Fix an issue with missing nextProps when calling a valueLink in the Textarea because of a bug introduce by #11 Fix Initial Select Value To Use ValueLink Value.

@SpiritBreaker226