### PR TITLE
Remove Missing File Link From Kitchen Sink

### DIFF
--- a/examples/kitchen-sink/coffeescript/kitchen-sink.html
+++ b/examples/kitchen-sink/coffeescript/kitchen-sink.html
@@ -2,14 +2,11 @@
   <head>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="../../../frigging-bootstrap.css">
   </head>
   <body>
     <div id="kitchen-sink" class="container" style="margin-top: 10px">
     </div>
     <script src="https://fb.me/react-with-addons-0.13.3.js"></script>
-    <script src="../../../frig.js"></script>
-    <script src="../../../frigging-bootstrap.js"></script>
     <script src="kitchen-sink.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Remove the missing file links in kitchen sink since they refer to  frigging bootstrap which is now in its own repo