### PR TITLE
Fix Saved List Use Component Name Instead Value

### DIFF
--- a/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
+++ b/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
@@ -16,7 +16,9 @@ AccountForm = React.createClass
       shareSketchyInfo: false
       time_of_night: false
       time_of_day: true
-      addresses: [{address: "55 Actual Place Rd."}, {}]
+      addresses: [{address: "55 Actual Place Rd.", default_shipping_address: true}, {
+        default_shipping_address: false
+      }]
       select_example: "thing-value"
       stuff_or_things: ["stuff-value"]
       single_select_typeahead: "stuff-value"
@@ -43,7 +45,7 @@ AccountForm = React.createClass
       time_of_day: true
       time_of_night: false
       shareSketchyInfo: false
-      addresses: [{address: true}, {}]
+      addresses: [{address: "This is a true test", default_shipping_address: false}, {}]
     # errors: ["Test Error", "Moo"]
     onSubmit: @onSubmit,
     # layout: "horizontal"
@@ -210,6 +212,7 @@ AccountForm = React.createClass
               f.input "address"
               f.input "city"
               f.input "postal_code"
+              f.input "default_shipping_address"
 
         div className: "row",
           div className: "col-xs-12",

--- a/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
+++ b/examples/kitchen-sink/coffeescript/kitchen-sink.coffee
@@ -14,6 +14,8 @@ AccountForm = React.createClass
       email: "me@test.com"
       password: "test"
       shareSketchyInfo: false
+      time_of_night: false
+      time_of_day: true
       addresses: [{address: "55 Actual Place Rd."}, {}]
       select_example: "thing-value"
       stuff_or_things: ["stuff-value"]
@@ -39,6 +41,8 @@ AccountForm = React.createClass
     saved:
       select_example: true
       time_of_day: true
+      time_of_night: false
+      shareSketchyInfo: false
       addresses: [{address: true}, {}]
     # errors: ["Test Error", "Moo"]
     onSubmit: @onSubmit,

--- a/src/javascripts/components/form.js
+++ b/src/javascripts/components/form.js
@@ -277,7 +277,7 @@ export default class FrigForm extends React.Component {
         requestChange: this._onChildRequestChange.bind(this, [name]),
       },
       internalErrors: this.props.errors[name],
-      saved: this.props.saved.hasOwnProperty(name),
+      saved: this.props.saved[name],
     }
   }
 

--- a/src/javascripts/components/form.js
+++ b/src/javascripts/components/form.js
@@ -277,7 +277,7 @@ export default class FrigForm extends React.Component {
         requestChange: this._onChildRequestChange.bind(this, [name]),
       },
       internalErrors: this.props.errors[name],
-      saved: this.props.saved[name],
+      saved: this.props.saved.hasOwnProperty(name),
     }
   }
 
@@ -343,7 +343,7 @@ export default class FrigForm extends React.Component {
       onComponentMount: this.childComponentWillMount.bind(this, [name]),
       onComponentUnmount: this.childComponentWillUnmount.bind(this, [name]),
       internalErrors: this.props.errors[name],
-      saved: this.props.saved[name],
+      saved: this.props.saved.hasOwnProperty(name),
     }
   }
 

--- a/src/javascripts/components/nested_fieldset.js
+++ b/src/javascripts/components/nested_fieldset.js
@@ -9,7 +9,7 @@ export default class NestedFieldset extends React.Component {
     theme: React.PropTypes.object.isRequired,
     typeMapping: React.PropTypes.objectOf(React.PropTypes.string),
     errors: React.PropTypes.object,
-    saved: React.PropTypes.object,
+    saved: React.PropTypes.array,
   }
 
   state = {


### PR DESCRIPTION
Fix the saved list use to the component name instead of its value because for switches and checkboxes they can return a boolean value  which could turn off the saved label when they change. 

Also, fix a nested fieldset warning for its saved list. It was using the wrong props type.