### PR TITLE
Remove Format Default From Number Component

### DIFF
--- a/docs/bootstrap_components.md
+++ b/docs/bootstrap_components.md
@@ -50,7 +50,7 @@ In addition to the properties listed under each component on this page and on th
 
 ```jsx
 <f.input name="example" component="number"
-  {/* Uses [numeral.js][http://numeraljs.com] format. Defaults to: "0,0[.][00]" */}
+  {/* Uses [numeral.js][http://numeraljs.com] format. */}
   format={"0,0.00"}
   {/* The minimum number allowed */}
   min={3}


### PR DESCRIPTION
Remove the Format Default From Number component because there will be no default format in the Number component.