### PR TITLE
Fix Validation Min / Max To Check For Null Values

### DIFF
--- a/src/validations.js
+++ b/src/validations.js
@@ -12,13 +12,13 @@ module.exports = {
 
   min: function (props, opts) {
     let {value} = props.valueLink
-    if (value >= opts || value != null || value === '') return undefined
+    if (value >= opts || value == null || value === '') return undefined
     return `Value cannot be less than ${opts}`
   },
 
   max: function (props, opts) {
     let {value} = props.valueLink
-    if (value <= opts || value != null || value === '') return undefined
+    if (value <= opts || value == null || value === '') return undefined
     return `Value cannot be greater than ${opts}`
   },
 }


### PR DESCRIPTION
Fix the validation min / max to check for null values in order to validate the value and not have false positives.