### PR TITLE
Add factories for non-JSX users

### DIFF
--- a/src/factories.js
+++ b/src/factories.js
@@ -1,5 +1,9 @@
 import Form from "./components/form.js"
 import Input from "./components/input.js"
+import Submit from "./components/submit.js"
+import FormErrorList from "./components/form_error_list.js"
 
 export const form = React.createFactory(Form)
 export const input = React.createFactory(Input)
+export const submit = React.createFactory(Submit)
+export const formErrorList = React.createFactory(FormErrorList)

--- a/src/factories.js
+++ b/src/factories.js
@@ -1,3 +1,4 @@
+import React from "react"
 import Form from "./components/form.js"
 import Input from "./components/input.js"
 import Submit from "./components/submit.js"

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import FieldsetText from "./components/fieldset_text.js"
 import ValueLinkedSelect from "./components/value_linked_select.js"
 import util from "./util.js"
 import typeMapping from "./type_mapping.js"
+import * as factories from "./factories.js"
 
 const HigherOrderComponents = {
   Boolean: require("./higher_order_components/boolean.js"),
@@ -33,4 +34,5 @@ export default {
   HigherOrderComponents,
   util,
   typeMapping,
+  factories,
 }


### PR DESCRIPTION
For non-JSX users, React component factories must be exported.

This PR exports all existing factories, and adds 2 factories for `Submit` and `FormErrorList`.