### PR TITLE
[do not merge] On Form, set defaultProp for `data` to empty object

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -36,6 +36,7 @@ export default class Form extends AbstractForm {
   }
 
   static defaultProps = {
+    data: {},
     errors: [],
     saved: {},
     theme: undefined,


### PR DESCRIPTION
This PR makes `data` an optional field on Frig forms.

This incidentally fixes some issues we've had with the Coffeescript DSL, but it's unclear whether this is even a good idea or not. What use is a Frig form without a `data` attribute?

Discuss?