### PR TITLE
<FormErrorList/> not displaying any errors

### DIFF
--- a/docs/core_components.md
+++ b/docs/core_components.md
@@ -113,7 +113,7 @@ import {Form, FormErrorList} from "frig"
 The errorList component renders all the form-level errors in the form's `props.errors`.
 
 #### Props
-* **baseField (optional)** - a string. The field in `props.errors` to look up form-level errors. Defaults to "base" for compatibility with Active Record.
+* **name (optional)** - a string. The field in `props.errors` to look up form-level errors. Defaults to "base" for compatibility with Active Record.
 
 ## \<Fieldset/\>
 

--- a/docs/core_components.md
+++ b/docs/core_components.md
@@ -11,7 +11,7 @@ import {Form, Input} from "frig"
 
 * **data (required)** - This is used to populate the values (including default values) of each field in the form. The data property is also used by inputs for type inference where a `type` property is not provided.
 * **onChange(data) (required)** - the onChange callback will be updated whenever there is user input. The onChange function receives the full updated data of the form as it's only argument. Normally this is used to update your store or setState and trigger a re-render passing the new data back in to the form.
-* **errors (optional)** - an array of strings. The list of errors supplied here can be rendered by the `<ErrorList/>` component.
+* **errors (optional)** - an array of strings. The list of errors supplied here can be rendered by the `<FormErrorList/>` component.
 * **onSubmit (optional)** - a function. Called after the submit button is clicked and all validations have passed. The DOM event is passed to the callback.
 * **layout (optional)**  - a string. Either `"horizontal"` for a horizontally layed out form (with labels on the same row as their inputs) or `"vertical"` for a vertically layed out form (with labels above their inputs). Defaults to `"vertical"`.
 * **align (optional)** - a string. Either `"left"` to align all inputs along the left side of their containing divs or `"right"` to align all inputs on the right side of their containing divs. Defaults to `"left"`.
@@ -101,16 +101,19 @@ import {Form, Submit} from "frig"
 #### Props
 * **title (optional)** - a string. The text of the submit button.
 
-## \<ErrorList/\>
+## <\FormErrorList/\>
 
 ```jsx
-import {Form, ErrorList} from "frig"
+import {Form, FormErrorList} from "frig"
 <Form data={this.state.myAccount} onChange={(myAccount) => this.setState({myAccount})}>
-  <ErrorList/>
+  <FormErrorList/>
 </Form>
 ```
 
 The errorList component renders all the form-level errors in the form's `props.errors`.
+
+#### Props
+* **baseField (optional)** - a string. The field in `props.errors` to look up form-level errors. Defaults to "base" for compatibility with Active Record.
 
 ## \<Fieldset/\>
 

--- a/src/components/form_error_list.js
+++ b/src/components/form_error_list.js
@@ -6,7 +6,7 @@ export default class FormErrorList extends React.Component {
   static defaultProps = {
     // This is the property of `errors` where Frig will look for form-level errors.
     // Set to "base" by default, for compatibility with Active Record.
-    baseField: "base",
+    name: "base",
   }
 
   static contextTypes = {
@@ -17,8 +17,8 @@ export default class FormErrorList extends React.Component {
 
   _errorsArray() {
     const { errors } = this.context.frigForm
-    const { baseField } = this.props
-    return errors.hasOwnProperty(baseField)
+    const { name } = this.props
+    return errors.hasOwnProperty(name)
       ? errors.base
       : []
   }

--- a/src/components/form_error_list.js
+++ b/src/components/form_error_list.js
@@ -18,9 +18,7 @@ export default class FormErrorList extends React.Component {
   _errorsArray() {
     const { errors } = this.context.frigForm
     const { name } = this.props
-    return errors.hasOwnProperty(name)
-      ? errors.base
-      : []
+    return errors[name] || []
   }
 
   render() {

--- a/src/components/form_error_list.js
+++ b/src/components/form_error_list.js
@@ -3,6 +3,12 @@ import React from "react"
 export default class FormErrorList extends React.Component {
   displayName = "Frig.FormErrorList"
 
+  static defaultProps = {
+    // This is the property of `errors` where Frig will look for form-level errors.
+    // Set to "base" by default, for compatibility with Active Record.
+    baseField: "base",
+  }
+
   static contextTypes = {
     frigForm: React.PropTypes.shape({
       errors: React.PropTypes.object.isRequired,
@@ -11,7 +17,8 @@ export default class FormErrorList extends React.Component {
 
   _errorsArray() {
     const { errors } = this.context.frigForm
-    return errors.hasOwnProperty("base")
+    const { baseField } = this.props
+    return errors.hasOwnProperty(baseField)
       ? errors.base
       : []
   }

--- a/src/components/form_error_list.js
+++ b/src/components/form_error_list.js
@@ -5,11 +5,19 @@ export default class FormErrorList extends React.Component {
 
   static contextTypes = {
     frigForm: React.PropTypes.shape({
-      theme: React.PropTypes.object.isRequired,
+      errors: React.PropTypes.object.isRequired,
     }).isRequired,
   }
+
+  _errorsArray() {
+    const { errors } = this.context.frigForm
+    return errors.hasOwnProperty("base")
+      ? errors.base
+      : []
+  }
+
   render() {
-    let ThemedErrorList = this.context.frigForm.theme.component("errors")
-    return <ThemedErrorList {...this.props}/>
+    const ThemedErrorList = this.context.frigForm.theme.component("errors")
+    return <ThemedErrorList errors={this._errorsArray()} />
   }
 }


### PR DESCRIPTION
Since the refactor to JSX (0.9.x), `<FormErrorList/>` has not been rendering any errors.

This PR:

* extracts `errors` from `context.frigForm` 
* only considers form-level errors, omits input-level errors (provides `errors['base']` as a prop to the frigging-bootstrap `<ThemedErrorList>`)
* allows user to customize which field contains form-level errors via `baseField` prop (default: `"base"`)
* updates docs

There will also be a corresponding PR for `frigging-bootstrap`.