### PR TITLE
Fix Focusable To Remove _onFocus() When Unmounting

### DIFF
--- a/src/higher_order_components/focusable.js
+++ b/src/higher_order_components/focusable.js
@@ -33,7 +33,7 @@ module.exports = function(ComponentClass) {
 
     componentWillUnmount() {
       window.removeEventListener("click", this._onDocumentClick)
-      window.removeEventListener("focus", this._onFocus)
+      window.removeEventListener("focus", this._onFocus, true)
     }
 
     _onDocumentClick(e) {


### PR DESCRIPTION
Fix the Focusable to remove _onFocus() when unmounting for all DOM elements that uses EventTarget in order to remove all _onFocus() from the DOM tree when the user leaves the section.