### PR TITLE
<Form/>: Throw if `data` or `onChange` are undefined

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -22,6 +22,15 @@ import AbstractForm from "./abstract_form.js"
 export default class Form extends AbstractForm {
   displayName = "Form"
 
+  componentWillMount() {
+    if (!this.props.data) {
+      throw new Error("Frig: Expression in <Form data={} /> must always be defined, got: " + this.props.data)
+    }
+    if (!this.props.onChange) {
+      throw new Error("Frig: Expression in <Form onChange={} /> must always be defined, got: " + this.props.onChange)
+    }
+  }
+
   static propTypes = {
     data: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func.isRequired,


### PR DESCRIPTION
Provides a better error message (and fails fast) when `<Form/>`'s  `data` or `onChange` props are null or undefined.

Consumers of Frig will have to be sure that the expression they set in `<Form data={...} />` always returns an object. If it returns `undefined` (e.g. on the initial load of an empty form), this error will be thrown.

Also see closed PR #34 for more information about how we could have handled this differently.