### PR TITLE
Fix Fieldset Fields To Show Saved On Correct Field

### DIFF
--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -40,9 +40,7 @@ export default class Fieldset extends React.Component {
   }
 
   modifications() {
-    let values = this._forms()
-      .filter((form) => form.isModified())
-      .map((form) => form.modifications())
+    let values = this._forms().map((form) => form.modifications())
     let isArray = Array.isArray(
       this.context.frigForm.data[this.props.name] || []
     )


### PR DESCRIPTION
Fix the Fieldset Fields to show saved label, on the correct fields. Since correctly the filter is removing an elements, in the Fieldset Field array, that is not modified. Because of this the saved label is only displaying, on the first field, as that will always be only element in the array.