### PR TITLE
Fix Running Coveralls On Fork Pull Request

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,4 @@ test:
   pre:
     - npm run lint:failfast
   post:
-    - npm run coveralls
+    - '[ -z "${CIRCLE_PR_USERNAME}" ] && npm run coveralls || false'

--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,4 @@ test:
   pre:
     - npm run lint:failfast
   post:
-    - '[ -z "${CIRCLE_PR_USERNAME}" ] && npm run coveralls || false'
+    - '[ -z "${CIRCLE_PR_USERNAME}" ] && npm run coveralls || true'


### PR DESCRIPTION
Fix running of Coveralls if the pull request is coming from a fork version, of the repo. Because CricleCI blocks custom environment variables from running, if the pull request is coming, from a different repo. This is to prevent a developer from scrapping environment variables when the application runs on CricleCI.