### PR TITLE
Fix Form's Higher Order Components and Other Components

### DIFF
--- a/src/components/fieldset_text.js
+++ b/src/components/fieldset_text.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const FieldsetText = (props, context) => {
-  const spanProps = Object.assign({}, this.props)
+  const spanProps = Object.assign({}, props)
   delete spanProps.text
   return (
     <span {...spanProps}>

--- a/src/components/unbound_input.js
+++ b/src/components/unbound_input.js
@@ -17,7 +17,7 @@ import { entries, humanize } from '../util.js'
 export default class UnboundInput extends React.Component {
   static propTypes = {
     name: React.PropTypes.string.isRequired,
-    errors: React.PropTypes.arrayOf(React.PropTypes.string),
+    errors: React.PropTypes.array,
     layout: React.PropTypes.string,
     align: React.PropTypes.string,
     className: React.PropTypes.string,

--- a/src/higher_order_components/delegates_public_functions.js
+++ b/src/higher_order_components/delegates_public_functions.js
@@ -1,9 +1,8 @@
-const DelegatesPublicFunctions = opts => hoc => {
+export default (opts) => (hoc) => {
   // delegate all the public functions of the child component to the child
   for (const k of opts.publicFunctions || []) {
-    const fn = () => this.refs.child[k](...arguments)
-    hoc.prototype[k] = fn  // eslint-disable-line no-param-reassign
+    hoc.prototype[k] = function () { // eslint-disable-line no-param-reassign, func-names
+      return this.refs.child[k](...arguments) // eslint-disable-line prefer-rest-params
+    }
   }
 }
-
-export default DelegatesPublicFunctions

--- a/src/higher_order_components/errors_normalizer.js
+++ b/src/higher_order_components/errors_normalizer.js
@@ -35,7 +35,7 @@ export default class ErrorNormalizer extends React.Component {
     const normalizedErrorClass = this.opts().as
     // Convert the errors object into the normalized error class
     if (normalizedErrorClass === Array) {
-      return errors.map((k) => errors[k])
+      return Object.keys(errors).map((k) => errors[k])
     }
     if (normalizedErrorClass === Object) {
       return errors

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ function defaultTheme(theme) {
 // All other exports are named and must be imported/destructured.
 export default {
   defaultTheme,
+  typeMapping,
 }
 
 export {
@@ -43,6 +44,5 @@ export {
   ValueLinkedSelect,
   HigherOrderComponents,
   util,
-  typeMapping,
   factories,
 }


### PR DESCRIPTION
 - Fix higher order components Error Normalizer & Delegates Public Functions to not display errors when rendering on the Frig Form.
 - Fix errors in Fieldset and Unbound Input
 - Move the Type Mapping to export default, in Index.js, because to allow the developer to develop components of a theme for each of the types that Frig allows to be rendered.