### PR TITLE
(WIP/do not merge) Add unbound input test

### DIFF
--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -35,10 +35,6 @@ const defaultContext = {
   },
 }
 
-const defaultChildContextTypes = {
-  frigForm: React.PropTypes.object.isRequired,
-}
-
 const defaultProps = {
   name: 'some_input',
   type: 'string',
@@ -46,7 +42,7 @@ const defaultProps = {
 
 describe('<Input />', () => {
   it('renders an <UnboundInput> with the correct props', () => {
-    const opts = { context: defaultContext, defaultChildContextTypes }
+    const opts = { context: defaultContext }
     const wrapper = mount(<Input {...defaultProps} />, opts)
     const unboundInput = wrapper.find('UnboundInput')
     const unboundProps = unboundInput.props()
@@ -77,7 +73,7 @@ describe('<Input />', () => {
     context.frigForm.requestChildComponentChange = requestChildComponentChange
 
     // mount component
-    const opts = { context, defaultChildContextTypes }
+    const opts = { context }
     const wrapper = mount(<Input {...props} />, opts)
 
     // act

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -1,0 +1,74 @@
+/* global describe, it, beforeEach */
+
+import React from 'react'
+import { expect } from 'chai'
+import UnboundInput from '../../src/components/unbound_input'
+import { mount } from 'enzyme'
+// import td from 'testdouble'
+
+const Stub = () => <div />
+const defaultContext = {
+  frigForm: {
+    theme: {
+      Input: Stub,
+    },
+    layout: 'some_layout',
+    align: 'some_align',
+  },
+}
+
+const defaultChildContextTypes = {
+  frigForm: React.PropTypes.object.isRequired,
+}
+
+const defaultProps = {
+  name: 'some_unbound_input',
+  type: 'string',
+}
+
+
+describe('<UnboundInput />', () => {
+  const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+  const UndecoratedUnboundInput = UnboundInput.originalClass
+  const wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
+  const instance = wrapper.instance()
+
+  it('isValid() returns true when errors is empty', () => {
+    expect(instance.isValid()).to.be.true()
+  })
+
+  it('isModified() returns state.modified', () => {
+    expect(instance.isModified()).to.be.false()
+    instance.setState({ modified: true })
+    expect(instance.isModified()).to.be.true()
+  })
+
+  it('resetModified() sets state.modified to false', () => {
+    wrapper.setState({ modified: true })
+    instance.resetModified()
+    expect(instance.isModified()).to.be.false()
+  })
+
+  it('reset() sets modified/validationRequested to false', () => {
+    wrapper.setState({ modified: true, validationRequested: true })
+    instance.reset()
+    expect(wrapper.state('modified')).to.be.false()
+    expect(wrapper.state('validationRequested')).to.be.false()
+  })
+
+  it('validate()')
+  it('render()')
+
+  describe('private functions', () => {
+    it('_errors')
+    it('_value')
+    it('_themedInputProps')
+    it('_normalizeOption')
+    it('_validations')
+    it('_onChange')
+    it('_onBlur')
+    it('_guessInputType')
+    it('_typeMapping')
+    it('_themedComponent')
+  })
+})


### PR DESCRIPTION
This PR:

* Removes unused `childContextTypes` from `input.test.js`.
* Adds tests for `<UnboundInput>`, including several WIP/pending tests

Note that `childContextTypes` is actually necessary for this test, because `UnboundInput` is actually an `ErrorNormalizer`-wrapped component. (We can also get around this by using `UnboundInput.originalClass`, which we've done for a few tests.)

