### PR TITLE
Add unbound input test

### DIFF
--- a/src/components/unbound_input.js
+++ b/src/components/unbound_input.js
@@ -245,7 +245,7 @@ export default class UnboundInput extends React.Component {
       return 'boolean'
     } else if (jsType === 'number') {
       return 'float'
-    } else if (this.props.name.match(/password$/i)) {
+    } else if (this.props.name.match(/password/i)) {
       return 'password'
     }
 
@@ -263,14 +263,15 @@ export default class UnboundInput extends React.Component {
   }
 
   _themedComponent() {
-    const { name } = this.props
-    const type = this._typeMapping().component
-    const component = this.context.frigForm.theme[type]
-    if (type == null) {
-      throw new Error(`${name}: No type mapping found`)
+    const { name, type } = this.props
+    const typeName = this._typeMapping()
+    if (typeName == null) {
+      throw new Error(`${name}: No type mapping found for type ${type}`)
     }
+
+    const component = this.context.frigForm.theme[typeName.component]
     if (component == null) {
-      throw new Error(`${name}: No ${type} component found in theme`)
+      throw new Error(`${name}: No ${typeName.component} component found in theme`)
     }
     return component
   }

--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -35,10 +35,6 @@ const defaultContext = {
   },
 }
 
-const defaultChildContextTypes = {
-  frigForm: React.PropTypes.object.isRequired,
-}
-
 const defaultProps = {
   name: 'some_input',
   type: 'string',
@@ -46,7 +42,7 @@ const defaultProps = {
 
 describe('<Input />', () => {
   it('renders an <UnboundInput> with the correct props', () => {
-    const opts = { context: defaultContext, defaultChildContextTypes }
+    const opts = { context: defaultContext }
     const wrapper = mount(<Input {...defaultProps} />, opts)
     const unboundInput = wrapper.find('UnboundInput')
     const unboundProps = unboundInput.props()
@@ -77,7 +73,7 @@ describe('<Input />', () => {
     context.frigForm.requestChildComponentChange = requestChildComponentChange
 
     // mount component
-    const opts = { context, defaultChildContextTypes }
+    const opts = { context }
     const wrapper = mount(<Input {...props} />, opts)
 
     // act

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -1,0 +1,74 @@
+/* global describe, it, beforeEach */
+
+import React from 'react'
+import { expect } from 'chai'
+import UnboundInput from '../../src/components/unbound_input'
+import { mount } from 'enzyme'
+// import td from 'testdouble'
+
+const Stub = () => <div />
+const defaultContext = {
+  frigForm: {
+    theme: {
+      Input: Stub,
+    },
+    layout: 'some_layout',
+    align: 'some_align',
+  },
+}
+
+const defaultChildContextTypes = {
+  frigForm: React.PropTypes.object.isRequired,
+}
+
+const defaultProps = {
+  name: 'some_unbound_input',
+  type: 'string',
+}
+
+
+describe('<UnboundInput />', () => {
+  const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+  const UndecoratedUnboundInput = UnboundInput.originalClass
+  const wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
+  const instance = wrapper.instance()
+
+  it('isValid() returns true when errors is empty', () => {
+    expect(instance.isValid()).to.be.true()
+  })
+
+  it('isModified() returns state.modified', () => {
+    expect(instance.isModified()).to.be.false()
+    instance.setState({ modified: true })
+    expect(instance.isModified()).to.be.true()
+  })
+
+  it('resetModified() sets state.modified to false', () => {
+    wrapper.setState({ modified: true })
+    instance.resetModified()
+    expect(instance.isModified()).to.be.false()
+  })
+
+  it('reset() sets modified/validationRequested to false', () => {
+    wrapper.setState({ modified: true, validationRequested: true })
+    instance.reset()
+    expect(wrapper.state('modified')).to.be.false()
+    expect(wrapper.state('validationRequested')).to.be.false()
+  })
+
+  it('validate()')
+  it('render()')
+
+  describe('private functions', () => {
+    it('_errors')
+    it('_value')
+    it('_themedInputProps')
+    it('_normalizeOption')
+    it('_validations')
+    it('_onChange')
+    it('_onBlur')
+    it('_guessInputType')
+    it('_typeMapping')
+    it('_themedComponent')
+  })
+})

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -55,6 +55,13 @@ describe('<UnboundInput />', () => {
       it('render() returns the themed component', () => {
         const themedComponent = wrapper.find(Stub)
         expect(themedComponent).to.have.length(1)
+
+        const themedProps = themedComponent.props()
+
+        expect(themedProps.layout).to.equal('some_layout')
+        expect(themedProps.align).to.equal('some_align')
+        expect(themedProps.inputHtml).to.exist()
+        expect(themedProps.valueLink).to.exist()
       })
     })
 
@@ -130,14 +137,52 @@ describe('<UnboundInput />', () => {
 
     it('_value', () => {
       const value = 'something more'
-      const prop = Object.assign({}, defaultProps, { value })
-      const wrapper = mount(<UndecoratedUnboundInput {...prop} />, opts)
+      const props = Object.assign({}, defaultProps, { value })
+      const wrapper = mount(<UndecoratedUnboundInput {...props} />, opts)
       const instance = wrapper.instance()
       expect(instance._value()).to.equal(value)
     })
 
-    it('_themedInputProps')
-    it('_normalizeOption')
+    describe('_normalizeOption', () => {
+      const testNormalizeOption = (option, expected) => {
+        const wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
+        const instance = wrapper.instance()
+        const result = instance._normalizeOption(option)
+        expect(result).to.deep.equal(expected)
+      }
+
+      it('return undefined when option is null', () => {
+        testNormalizeOption(null, undefined)
+      })
+
+      it('object in form {label,value} gets passed through', () => {
+        testNormalizeOption(
+          { value: 'l', label: 'v' },
+          { value: 'l', label: 'v' },
+        )
+      })
+
+      it('one element array gets converted to {value,label} (value=label)', () => {
+        testNormalizeOption(
+          ['xxx'],
+          { value: 'xxx', label: 'xxx' }
+        )
+      })
+
+      it('two element array gets converted to {value,label}', () => {
+        testNormalizeOption(
+          ['x', 'y'],
+          { value: 'x', label: 'y' }
+        )
+      })
+
+      it('string gets converted to {value,label} (value=label)', () => {
+        testNormalizeOption(
+          'string',
+          { value: 'string', label: 'string' }
+        )
+      })
+    })
 
     describe('detected errors', () => {
       describe('_errors', () => {

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -26,38 +26,68 @@ const defaultProps = {
   type: 'string',
 }
 
-
 describe('<UnboundInput />', () => {
-  const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
-  const UndecoratedUnboundInput = UnboundInput.originalClass
-  const wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
-  const instance = wrapper.instance()
+  describe('public methods except validate', () => {
+    let wrapper
+    let instance
 
-  it('isValid() returns true when errors is empty', () => {
-    expect(instance.isValid()).to.be.true()
+    beforeEach(() => {
+      const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+      const UndecoratedUnboundInput = UnboundInput.originalClass
+      wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
+      instance = wrapper.instance()
+    })
+
+    it('isValid() returns true when errors is empty', () => {
+      expect(instance.isValid()).to.be.true()
+    })
+
+    it('isModified() returns state.modified', () => {
+      expect(instance.isModified()).to.be.false()
+      instance.setState({ modified: true })
+      expect(instance.isModified()).to.be.true()
+    })
+
+    it('resetModified() sets state.modified to false', () => {
+      wrapper.setState({ modified: true })
+      instance.resetModified()
+      expect(instance.isModified()).to.be.false()
+    })
+
+    it('reset() sets modified/validationRequested to false', () => {
+      instance.reset()
+      expect(wrapper.state('modified')).to.be.false()
+      expect(wrapper.state('validationRequested')).to.be.false()
+    })
+
+    it('render() returns the themed component', () => {
+      const themedComponent = wrapper.find(Stub)
+      expect(themedComponent).to.have.length(1)
+    })
   })
 
-  it('isModified() returns state.modified', () => {
-    expect(instance.isModified()).to.be.false()
-    instance.setState({ modified: true })
-    expect(instance.isModified()).to.be.true()
-  })
+  describe('validate()', () => {
+    const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
 
-  it('resetModified() sets state.modified to false', () => {
-    wrapper.setState({ modified: true })
-    instance.resetModified()
-    expect(instance.isModified()).to.be.false()
-  })
+    it('sets validationRequested', () => {
+      const wrapper = mount(<UnboundInput.originalClass {...defaultProps} />, opts)
+      const instance = wrapper.instance()
+      instance.validate()
+      expect(wrapper.state('validationRequested')).to.be.true()
+    })
 
-  it('reset() sets modified/validationRequested to false', () => {
-    wrapper.setState({ modified: true, validationRequested: true })
-    instance.reset()
-    expect(wrapper.state('modified')).to.be.false()
-    expect(wrapper.state('validationRequested')).to.be.false()
-  })
+    it('returns true when there is an error on the field', () => {
+      const props = Object.assign({}, defaultProps, {
+        errors: {
+          some_unbound_input: ['some error'],
+        },
+      })
 
-  it('validate()')
-  it('render()')
+      const wrapper = mount(<UnboundInput {...props} />, opts)
+      const instance = wrapper.instance()
+      expect(instance.validate()).to.be.false()
+    })
+  })
 
   describe('private functions', () => {
     it('_errors')

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { expect } from 'chai'
 import UnboundInput from '../../src/components/unbound_input'
 import { mount } from 'enzyme'
-// import td from 'testdouble'
+import td from 'testdouble'
 
 const Stub = () => <div />
 const defaultContext = {
@@ -90,15 +90,167 @@ describe('<UnboundInput />', () => {
   })
 
   describe('private functions', () => {
-    it('_errors')
-    it('_value')
+    const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+    const UndecoratedUnboundInput = UnboundInput.originalClass
+
+    it('_value', () => {
+      const value = 'something more'
+      const prop = Object.assign({}, defaultProps, { value })
+      const wrapper = mount(<UndecoratedUnboundInput {...prop} />, opts)
+      const instance = wrapper.instance()
+      expect(instance._value()).to.equal(value)
+    })
+
     it('_themedInputProps')
     it('_normalizeOption')
-    it('_validations')
-    it('_onChange')
-    it('_onBlur')
-    it('_guessInputType')
-    it('_typeMapping')
-    it('_themedComponent')
+
+    describe('detected errors', () => {
+      describe('_errors', () => {
+        it('return undefined when props.errors is empty', () => {
+          const wrapper = mount(<UndecoratedUnboundInput {...defaultProps} />, opts)
+          const instance = wrapper.instance()
+          expect(instance._errors('some')).to.be.undefined()
+        })
+      })
+      it('_validations')
+    })
+
+    describe('events', () => {
+      describe('_onChange', () => {
+        const onChange = td.function()
+        const onValidChange = td.function()
+
+        beforeEach(() => { td.reset() })
+
+        const getWrapper = (overrideProps = {}) => {
+          const finalProps = {
+            ...defaultProps,
+            ...overrideProps,
+            onChange,
+            onValidChange,
+          }
+          return mount(<UndecoratedUnboundInput {...finalProps} />, opts)
+        }
+
+        it('sets state.modified by default', () => {
+          const wrapper = getWrapper()
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value', {})
+
+          const modified = wrapper.state('modified')
+          expect(modified).to.be.true()
+        })
+
+        it('does not set state.modified when opts.setModified=false', () => {
+          const wrapper = getWrapper()
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value', { setModified: false })
+
+          const modified = wrapper.state('modified')
+          expect(modified).to.be.false()
+        })
+
+        it('always calls props.onChange', () => {
+          const wrapper = getWrapper()
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value')
+
+          td.verify(onChange('some_value', true))
+        })
+
+        it('calls props.onValidChange when there are no errors', () => {
+          const wrapper = getWrapper({ value: 'some_value' })
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value')
+
+          td.verify(onValidChange('some_value', true))
+        })
+
+        it('does not call props.onValidChange when there are errors', () => {
+          const wrapper = getWrapper({ value: 66, max: 5 })
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value')
+
+          td.verify(onValidChange(), { times: 0 })
+        })
+
+
+        it('does not call props.on[Valid]Change if type=submit', () => {
+          const wrapper = getWrapper({ type: 'submit' })
+          const instance = wrapper.instance()
+
+          instance._onChange('some_value')
+
+          td.verify(onValidChange(), { times: 0 })
+          td.verify(onChange(), { times: 0 })
+        })
+      })
+      describe('_onBlur', () => {
+        it('calls props.inputHtml.onBlur()', () => {
+          const onBlur = td.function()
+          const inputHtml = { onBlur }
+          const props = { ...defaultProps, inputHtml }
+          const wrapper = mount(<UndecoratedUnboundInput {...props} />, opts)
+
+          const instance = wrapper.instance()
+          instance._onBlur()
+
+          td.verify(onBlur())
+        })
+
+        it('doesnt call props.inputHtml.onBlur() if props.inputHtml is undefined', () => {
+          const props = { ...defaultProps }
+          const wrapper = mount(<UndecoratedUnboundInput {...props} />, opts)
+          const instance = wrapper.instance()
+          instance._onBlur()
+          // no assertion here: the test passes if it doesn't throw an exception
+        })
+      })
+    })
+
+    describe('detected type', () => {
+      describe('_guessInputType', () => {
+        const testGuessInputType = (props, expected) => {
+          // We don't want the type to always be `string`, let tests decide.
+          delete defaultProps.type
+          const nextProps = Object.assign({}, defaultProps, props)
+          const wrapper = mount(<UndecoratedUnboundInput {...nextProps} />, opts)
+          const result = wrapper.instance()._guessInputType()
+          expect(result).to.equal(expected)
+        }
+
+        it('passes through unrecognized types', () => {
+          testGuessInputType({ type: 'bogus' }, 'bogus')
+        })
+        it('when props.multiple, detects as multiselect', () => {
+          testGuessInputType({ multiple: true }, 'multiselect')
+        })
+        it('when value is an array, detects multiselect', () => {
+          testGuessInputType({ value: [1, 2, 3] }, 'multiselect')
+        })
+        it('detects select', () => {
+          testGuessInputType({ options: [1, 2, 3] }, 'select')
+        })
+        it('detects boolean', () => {
+          testGuessInputType({ value: true }, 'boolean')
+        })
+        it('detects float', () => {
+          testGuessInputType({ value: 6 }, 'float')
+        })
+        it('detects password', () => {
+          testGuessInputType({ name: 'Password' }, 'password')
+          testGuessInputType({ name: 'the_password_confirm' }, 'password')
+        })
+        it('when no type specified or detected, assume string', () => {
+          testGuessInputType({ bogus: 'bogus' }, 'string')
+        })
+      })
+      it('_typeMapping')
+    })
   })
 })

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -11,6 +11,19 @@ const defaultContext = {
   frigForm: {
     theme: {
       Input: Stub,
+      NoComponent: Stub,
+      type_mapping: {
+        bogus: { component: 'NoComponent' },
+        multiselect: { component: 'NoComponent' },
+        select: { component: 'NoComponent' },
+        boolean: { component: 'NoComponent' },
+        number: { component: 'NoComponent' },
+        float: { component: 'NoComponent' },
+        password: { component: 'NoComponent' },
+        string: { component: 'NoComponent' },
+        submit: { component: 'NoComponent' },
+        bad_component: { component: 'BadComponent' },
+      },
     },
     layout: 'some_layout',
     align: 'some_align',
@@ -38,6 +51,13 @@ describe('<UnboundInput />', () => {
       instance = wrapper.instance()
     })
 
+    describe('render()', () => {
+      it('render() returns the themed component', () => {
+        const themedComponent = wrapper.find(Stub)
+        expect(themedComponent).to.have.length(1)
+      })
+    })
+
     it('isValid() returns true when errors is empty', () => {
       expect(instance.isValid()).to.be.true()
     })
@@ -59,10 +79,25 @@ describe('<UnboundInput />', () => {
       expect(wrapper.state('modified')).to.be.false()
       expect(wrapper.state('validationRequested')).to.be.false()
     })
+  })
 
-    it('render() returns the themed component', () => {
-      const themedComponent = wrapper.find(Stub)
-      expect(themedComponent).to.have.length(1)
+  describe('exceptions during render()', () => {
+    it('throws if no type mapping found', () => {
+      const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+      const jsx = <UnboundInput.originalClass name="some_input" type="never_used_type" />
+      const wrapperBound = mount.bind(this, jsx, opts)
+
+      expect(wrapperBound).to.throw(Error, /No type mapping found/)
+      expect(wrapperBound).to.throw(Error, /some_input/)
+      expect(wrapperBound).to.throw(Error, /never_used_type/)
+    })
+
+    it('throws if no component found in theme', () => {
+      const opts = { context: defaultContext, childContextTypes: defaultChildContextTypes }
+      const jsx = <UnboundInput.originalClass name="some_input" type="bad_component" />
+      const wrapperBound = mount.bind(this, jsx, opts)
+
+      expect(wrapperBound).to.throw(Error, /some_input: No BadComponent component/)
     })
   })
 


### PR DESCRIPTION
This PR:

* Removes unused `childContextTypes` from `input.test.js`.
* Adds tests for `<UnboundInput>`, including several WIP/pending tests

Note that `childContextTypes` is actually necessary for this test, because `UnboundInput` is actually an `ErrorNormalizer`-wrapped component. (We can also get around this by using `UnboundInput.originalClass`, which we've done for a few tests.)
