### PR TITLE
Add Ignore Code Coverage, Public Function In Input

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -65,22 +65,27 @@ export default class Input extends React.Component {
    */
 
   validate() {
+    /* istanbul ignore next */
     return this.refs.unboundInput.validate()
   }
 
   isValid() {
+    /* istanbul ignore next */
     return this.refs.unboundInput.isValid()
   }
 
   isModified() {
+    /* istanbul ignore next */
     return this.refs.unboundInput.isModified()
   }
 
   resetModified() {
+    /* istanbul ignore next */
     return this.refs.unboundInput.resetModified()
   }
 
   reset() {
+    /* istanbul ignore next */
     return this.refs.unboundInput.reset()
   }
 


### PR DESCRIPTION
Add Ignore code coverage to public functions in Input component because those functions are just returning the results from UnboundInput's public functions so testing those will only be testing the results of functions which are already been tested.