### PR TITLE
Add Testing For Fieldset

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-register": "6.7.2",
     "chai": "3.5.0",
     "chai-enzyme": "0.4.1",
+    "cloner": "^0.4.0",
     "coveralls": "2.11.9",
     "dirty-chai": "1.2.2",
     "enzyme": "2.2.0",

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -19,7 +19,7 @@ export default class Fieldset extends React.Component {
   static propTypes = {
     name: React.PropTypes.string.isRequired,
     children: React.PropTypes.any.isRequired,
-    FieldsetNestedForm: React.PropTypes.element.isRequired,
+    FieldsetNestedForm: React.PropTypes.func.isRequired,
   }
 
   static defaultProps = {

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -79,6 +79,8 @@ export default class Fieldset extends React.Component {
 
   _contextAtIndex(index, keys) {
     return keys.reduce((contextAtIndex, key) => {
+      if (this.context.frigForm[key] == null) return {}
+
       const values = this.context.frigForm[key][this.props.name]
       const value = Array.isArray(values) ? values[index] : values
       contextAtIndex[key] = value || {}   // eslint-disable-line no-param-reassign

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -17,7 +17,7 @@ export default class Fieldset extends React.Component {
   }
 
   static propTypes = {
-    name: React.PropTypes.string,
+    name: React.PropTypes.string.isRequired,
     children: React.PropTypes.any.isRequired,
   }
 

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -1,4 +1,4 @@
-import FieldsetNestedForm from './fieldset_nested_form.js'
+import RealFieldsetNestedForm from './fieldset_nested_form.js'
 import React from 'react'
 
 export default class Fieldset extends React.Component {
@@ -19,6 +19,11 @@ export default class Fieldset extends React.Component {
   static propTypes = {
     name: React.PropTypes.string.isRequired,
     children: React.PropTypes.any.isRequired,
+    FieldsetNestedForm: React.PropTypes.element.isRequired,
+  }
+
+  static defaultProps = {
+    FieldsetNestedForm: RealFieldsetNestedForm,
   }
 
   displayName = 'Fieldset'
@@ -114,6 +119,7 @@ export default class Fieldset extends React.Component {
 
   render() {
     let i = 0
+    const { FieldsetNestedForm } = this.props
     const nestedFormDatas = this._nestedFormDatas()
     return (
       <div>

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -50,11 +50,19 @@ export default class Fieldset extends React.Component {
   }
 
   modifications() {
-    const values = this._forms().map((form) => form.modifications())
-    const isArray = Array.isArray(
-      this.context.frigForm.data[this.props.name] || []
-    )
-    return isArray ? values : values[0]
+    const mods = this._forms().map((form) => form.modifications())
+    const nestedFormData = this.context.frigForm.data[this.props.name]
+    if (nestedFormData == null) {
+      return []
+    }
+    const isArray = Array.isArray(nestedFormData)
+    if (!isArray) {
+      // for the edge case where frigForm.data.myFieldset is a single
+      // object instead of an array of objects
+      return mods[0]
+    }
+
+    return mods
   }
 
   resetModified() {
@@ -66,7 +74,7 @@ export default class Fieldset extends React.Component {
   }
 
   _forms() {
-    return Object.keys(this.refs || {}).map((k) => this.refs[k])
+    return Object.keys(this.refs).map((k) => this.refs[k])
   }
 
   _contextAtIndex(index, keys) {

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -51,10 +51,7 @@ export default class Fieldset extends React.Component {
 
   modifications() {
     const mods = this._forms().map((form) => form.modifications())
-    const nestedFormData = this.context.frigForm.data[this.props.name]
-    if (nestedFormData == null) {
-      return []
-    }
+    const nestedFormData = this.context.frigForm.data[this.props.name] || []
     const isArray = Array.isArray(nestedFormData)
     if (!isArray) {
       // for the edge case where frigForm.data.myFieldset is a single

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -1,0 +1,230 @@
+/* global describe, it, beforeEach */
+
+import React from 'react'
+import { expect } from 'chai'
+import Fieldset from '../../src/components/fieldset'
+import { mount } from 'enzyme'
+import td from 'testdouble'
+
+const Stub = () => <div />
+const defaultContext = {
+  frigForm: {
+    data: {
+      some_fieldset: [
+        { field1: 'Number 1', field2: 'Number 2' },
+        { field1: 'Number 3', field2: 'Number 4' },
+      ],
+      other_fieldset: [{ fieldOther2: 'Other 1' }],
+    },
+    theme: {
+      Input: Stub,
+    },
+    errors: {
+      some_fieldset: [{ field1: 'Some Other Error 1' }, {
+        field1: 'Some Other Error 1',
+        field2: 'Some Other Error 2',
+        field3: 'Some Other Error 3',
+      }],
+    },
+    layout: 'some_layout',
+    saved: {
+      some_fieldset: [{ field1: true }, {}],
+      other_fieldset: [{ fieldOther2: false }],
+    },
+    requestChildComponentChange: () => {},
+    childComponentWillMount: () => {},
+    childComponentWillUnmount: () => {},
+  },
+}
+
+const defaultProps = {
+  name: 'some_fieldset',
+  children: Stub,
+}
+
+describe('<Fieldset />', () => {
+  describe('Public Functions', () => {
+    let mockNestedForm
+
+    beforeEach(() => {
+      mockNestedForm = (replaceFunctions) =>
+        class FieldsetNestedForm extends React.Component {
+          constructor() {
+            super()
+            Object.keys(replaceFunctions).forEach((k) => {
+              this[k] = replaceFunctions[k]
+            })
+          }
+          render() { return <div /> }
+        }
+    })
+
+    describe('validate', () => {
+      it('calls FieldsetNestedForm.validate', () => {
+        const validate = td.function()
+        const isValid = td.function()
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm({ validate, isValid }),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        instance.validate()
+
+        td.verify(validate(), { times: 2 })
+      })
+    })
+
+    describe('isValid', () => {
+      it('return true when all nested form is true', () => {
+        // set up isValid test double to always return true
+        const isValid = td.function('isValid')
+        td.when(isValid()).thenReturn(true)
+
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm({ isValid }),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        expect(instance.isValid()).to.be.true()
+        td.verify(isValid(), { times: 2 })
+      })
+    })
+
+    describe('isModified', () => {
+      it('return true when all nested form is true', () => {
+        // set up isModified test double to return:
+        //   true on the first invocation,
+        //   false on the second invocation
+        const isModified = td.function('isModified')
+        td.when(isModified()).thenReturn(false, true)
+
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm({ isModified }),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        expect(instance.isModified()).to.be.true()
+        td.verify(isModified(), { times: 2 })
+      })
+    })
+
+    describe('modifications', () => {
+      it('returns an array of the children modifications', () => {
+        // set up modifcations test double to return:
+        //   field1 was modified on the first return,
+        //   nothing was modified on the second return
+        const modifications = td.function('modifications')
+        td.when(modifications()).thenReturn(
+          { field1: true, field2: false },
+          { field1: false, field2: false },
+        )
+
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm({ modifications }),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        const expected = [
+          { field1: true, field2: false },
+          { field1: false, field2: false },
+        ]
+
+        expect(instance.modifications()).to.deep.equal(expected)
+        td.verify(modifications(), { times: 2 })
+      })
+
+      it('if frigForm.data.myFieldset is 1 object, should return object not array', () => {
+        // rewrite context so that instead of data.some_fieldset being an
+        // array of objects, it is only one single object
+        const context = Object.assign({}, defaultContext)
+        const data = { field1: 'abc', field2: 'def' }
+        context.frigForm.data.some_fieldset = data
+
+        // test double
+        const modifications = td.function('modifications')
+        td.when(modifications()).thenReturn(
+          { field1: true, field2: false },
+        )
+
+        // mount and render
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm({ modifications }),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        // assert
+        const expected = { field1: true, field2: false }
+        expect(instance.modifications()).to.deep.equal(expected)
+      })
+
+      it('if frigForm.data.myFieldset is undefined, return empty array', () => {
+        // rewrite context so that instead of data.some_fieldset
+        // is undefined
+        const context = Object.assign({}, defaultContext)
+        delete context.frigForm.data.some_fieldset
+
+        // mount and render
+        const props = Object.assign({}, defaultProps, {
+          FieldsetNestedForm: mockNestedForm(),
+        })
+        const opts = { context: defaultContext }
+        const wrapper = mount(<Fieldset {...props} />, opts)
+        const instance = wrapper.instance()
+
+        // assert
+        const expected = []
+        expect(instance.modifications()).to.deep.equal(expected)
+      })
+    })
+
+    // describe('resetModified', () => {
+    //   it('return true when all nested form is true', () => {
+    //     // set up isModified test double to return:
+    //     //   true on the first invocation,
+    //     //   false on the second invocation
+    //     const resetModified = td.function()
+
+    //     const props = Object.assign({}, defaultProps, {
+    //       FieldsetNestedForm: mockNestedForm({ resetModified }),
+    //     })
+    //     const opts = { context: defaultContext }
+    //     const wrapper = mount(<Fieldset {...props} />, opts)
+    //     const instance = wrapper.instance()
+
+    //     instance.resetModified()
+
+    //     td.verify(resetModified(), { times: 2 })
+    //   })
+    // })
+
+    // describe('reset', () => {
+    //   it('return true when all nested form is true', () => {
+    //     // set up isModified test double to return:
+    //     //   true on the first invocation,
+    //     //   false on the second invocation
+    //     const reset = td.function()
+
+    //     const props = Object.assign({}, defaultProps, {
+    //       FieldsetNestedForm: mockNestedForm({ reset }),
+    //     })
+    //     const opts = { context: defaultContext }
+    //     const wrapper = mount(<Fieldset {...props} />, opts)
+    //     const instance = wrapper.instance()
+
+    //     instance.reset()
+
+    //     td.verify(reset(), { times: 2 })
+    //   })
+    // })
+  })
+})

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -87,7 +87,6 @@ describe('<Fieldset />', () => {
 
         const assertion = (instance) => {
           expect(instance.isValid()).to.be.true()
-          td.verify(isValid(), { times: 2 })
         }
         testPublicFunction(nestedForm, assertion)
       })
@@ -104,7 +103,6 @@ describe('<Fieldset />', () => {
 
         const assertion = (instance) => {
           expect(instance.isModified()).to.be.true()
-          td.verify(isModified(), { times: 2 })
         }
         testPublicFunction(nestedForm, assertion)
       })
@@ -128,7 +126,6 @@ describe('<Fieldset />', () => {
             { field1: false, field2: false },
           ]
           expect(instance.modifications()).to.deep.equal(expected)
-          td.verify(modifications(), { times: 2 })
         }
         testPublicFunction(nestedForm, assertion)
       })

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -199,4 +199,52 @@ describe('<Fieldset />', () => {
       })
     })
   })
+
+  describe('Private Functions', () => {
+    describe('_contextAtIndex', () => {
+      const testContextAtIndex = (context, expected, keys = ['errors']) => {
+        const instance = mountFieldset(context)
+        const assertion = instance._contextAtIndex(0, keys)
+        expect(assertion).to.deep.equal(expected)
+      }
+
+      it('return empty objects [error, saved] from defaultContext', () => {
+        const expected = {
+          errors: {},
+          saved: {},
+        }
+
+        testContextAtIndex(defaultContext, expected, ['errors', 'saved'])
+      })
+
+      it('returns empty object if no keys are found', () => {
+        const expected = {}
+
+        testContextAtIndex(defaultContext, expected, ['nothing'])
+      })
+
+      it('return an object with of errors', () => {
+        const context = cloner.deep.copy(defaultContext)
+        const errors = { some_fieldset: [{ field1: 'abc', field2: 'def' }] }
+        context.frigForm.errors = errors
+
+        const expected = {
+          errors: { field1: 'abc', field2: 'def' },
+        }
+        testContextAtIndex(context, expected)
+      })
+
+      it('if frigForm.errors is 1 object, should return object not array', () => {
+        const context = cloner.deep.copy(defaultContext)
+        const errors = { some_fieldset: { field1: 'abc', field2: 'def' } }
+        context.frigForm.errors = errors
+
+        const expected = {
+          errors: { field1: 'abc', field2: 'def' },
+        }
+
+        testContextAtIndex(context, expected)
+      })
+    })
+  })
 })

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -246,5 +246,48 @@ describe('<Fieldset />', () => {
         testContextAtIndex(context, expected)
       })
     })
+
+    describe('_onChange', () => {
+      let requestChildComponentChange
+      let instance
+      let context
+      const data = { field1: 'abc', field2: 'def' }
+
+      beforeEach(() => {
+        // test doubles
+        requestChildComponentChange = td.function()
+
+        // set context
+        context = cloner.deep.copy(defaultContext)
+        context.frigForm.requestChildComponentChange = requestChildComponentChange
+
+        // mount component
+        instance = mountFieldset(context)
+      })
+
+      it('returns a new array of the children change', () => {
+        // expected
+        context.frigForm.data.some_fieldset[1] = data
+        const expected = context.frigForm.data.some_fieldset
+
+        // mount
+        instance._onChange(1, data)
+
+        // assertion
+        td.verify(requestChildComponentChange('some_fieldset', expected))
+      })
+
+      it('when data is an object, should return object not array', () => {
+        // expected
+        context.frigForm.data.some_fieldset = data
+        const expected = context.frigForm.data.some_fieldset
+
+        // mount
+        instance._onChange(0, data)
+
+        // assertion
+        td.verify(requestChildComponentChange('some_fieldset', expected))
+      })
+    })
   })
 })

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -169,15 +169,12 @@ describe('<Fieldset />', () => {
       })
     })
 
-    describe('resetModified', () => {
+    describe('resetModified()', () => {
       it('return true when all nested form is true', () => {
         const resetModified = td.function()
         const nestedForm = mockNestedForm({ resetModified })
 
         const assertion = (instance) => {
-          // not sure what's going on here, for some reason
-          // this.refs is an empty object. Why for this and not others?
-
           instance.resetModified()
           td.verify(resetModified(), { times: 2 })
         }
@@ -185,24 +182,17 @@ describe('<Fieldset />', () => {
       })
     })
 
-    // describe('reset', () => {
-    //   it('return true when all nested form is true', () => {
-    //     // set up isModified test double to return:
-    //     //   true on the first invocation,
-    //     //   false on the second invocation
-    //     const reset = td.function()
+    describe('reset()', () => {
+      it('return true when all nested form is true', () => {
+        const reset = td.function()
+        const nestedForm = mockNestedForm({ reset })
 
-    //     const props = Object.assign({}, defaultProps, {
-    //       FieldsetNestedForm: mockNestedForm({ reset }),
-    //     })
-    //     const opts = { context: defaultContext }
-    //     const wrapper = mount(<Fieldset {...props} />, opts)
-    //     const instance = wrapper.instance()
-
-    //     instance.reset()
-
-    //     td.verify(reset(), { times: 2 })
-    //   })
-    // })
+        const assertion = (instance) => {
+          instance.reset()
+          td.verify(reset(), { times: 2 })
+        }
+        testPublicFunction(nestedForm, assertion)
+      })
+    })
   })
 })

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -37,6 +37,8 @@ const defaultProps = {
 // and calls some of its functions. This mock lets us change the behavior
 // of the child component so we can meaningfully test some of the public
 // methods which are just pass-thrus to the child.
+//
+// Pass in an object containing functions, e.g. { foo: () => {} }
 const mockNestedForm = (replaceFunctions) =>
   class FieldsetNestedForm extends React.Component {
     constructor() {
@@ -57,11 +59,10 @@ describe('<Fieldset />', () => {
       const opts = { context }
       const wrapper = mount(<Fieldset {...props} />, opts)
       const instance = wrapper.instance()
-
       assertionCallback(instance)
     }
 
-    describe('validate', () => {
+    describe('validate()', () => {
       it('calls FieldsetNestedForm.validate', () => {
         const validate = td.function()
         const isValid = td.function()
@@ -75,7 +76,7 @@ describe('<Fieldset />', () => {
       })
     })
 
-    describe('isValid', () => {
+    describe('isValid()', () => {
       it('return true when all nested form is true', () => {
         // set up isValid test double to always return true
         const isValid = td.function('isValid')
@@ -90,7 +91,7 @@ describe('<Fieldset />', () => {
       })
     })
 
-    describe('isModified', () => {
+    describe('isModified()', () => {
       it('return true when all nested form is true', () => {
         // set up isModified test double to return:
         //   true on the first invocation,
@@ -107,7 +108,7 @@ describe('<Fieldset />', () => {
       })
     })
 
-    describe('modifications', () => {
+    describe('modifications()', () => {
       it('returns an array of the children modifications', () => {
         // set up modifcations test double to return:
         //   field1 was modified on the first return,
@@ -168,25 +169,21 @@ describe('<Fieldset />', () => {
       })
     })
 
-    // describe('resetModified', () => {
-    //   it('return true when all nested form is true', () => {
-    //     // set up isModified test double to return:
-    //     //   true on the first invocation,
-    //     //   false on the second invocation
-    //     const resetModified = td.function()
+    describe('resetModified', () => {
+      it('return true when all nested form is true', () => {
+        const resetModified = td.function()
+        const nestedForm = mockNestedForm({ resetModified })
 
-    //     const props = Object.assign({}, defaultProps, {
-    //       FieldsetNestedForm: mockNestedForm({ resetModified }),
-    //     })
-    //     const opts = { context: defaultContext }
-    //     const wrapper = mount(<Fieldset {...props} />, opts)
-    //     const instance = wrapper.instance()
+        const assertion = (instance) => {
+          // not sure what's going on here, for some reason
+          // this.refs is an empty object. Why for this and not others?
 
-    //     instance.resetModified()
-
-    //     td.verify(resetModified(), { times: 2 })
-    //   })
-    // })
+          instance.resetModified()
+          td.verify(resetModified(), { times: 2 })
+        }
+        testPublicFunction(nestedForm, assertion)
+      })
+    })
 
     // describe('reset', () => {
     //   it('return true when all nested form is true', () => {

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -51,6 +51,12 @@ const mockNestedForm = (replaceFunctions) =>
     render() { return <div /> }
   }
 
+const mountFieldset = (context = defaultContext, props = defaultProps) => {
+  const opts = { context }
+  const wrapper = mount(<Fieldset {...props} />, opts)
+  return wrapper.instance()
+}
+
 describe('<Fieldset />', () => {
   afterEach(() => { td.reset() })
 
@@ -59,9 +65,7 @@ describe('<Fieldset />', () => {
       const props = Object.assign({}, defaultProps, {
         FieldsetNestedForm,
       })
-      const opts = { context }
-      const wrapper = mount(<Fieldset {...props} />, opts)
-      const instance = wrapper.instance()
+      const instance = mountFieldset(context, props)
       assertionCallback(instance)
     }
 

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -290,4 +290,32 @@ describe('<Fieldset />', () => {
       })
     })
   })
+
+  describe('React Lifecycle (Mount & Unmount)', () => {
+    it('Add & remove child component In context.frigForm', () => {
+      // test doubles
+      const childComponentWillMount = td.function()
+      const childComponentWillUnmount = td.function()
+
+      // set context
+      const context = cloner.deep.copy(defaultContext)
+      context.frigForm.childComponentWillMount = childComponentWillMount
+      context.frigForm.childComponentWillUnmount = childComponentWillUnmount
+
+      const opts = { context }
+
+      // mount
+      const wrapper = mount(<Fieldset {...defaultProps} />, opts)
+      const instance = wrapper.instance()
+
+      // verify that the child component has mounted
+      td.verify(childComponentWillMount('some_fieldset', instance))
+
+      // unmount
+      wrapper.unmount()
+
+      // verify that the child component has unmounted
+      td.verify(childComponentWillUnmount('some_fieldset', instance))
+    })
+  })
 })

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import Fieldset from '../../src/components/fieldset'
 import { mount } from 'enzyme'
 import td from 'testdouble'
+import cloner from 'cloner'
 
 const Stub = () => <div />
 const defaultContext = {
@@ -133,7 +134,7 @@ describe('<Fieldset />', () => {
       it('if frigForm.data.myFieldset is 1 object, should return object not array', () => {
         // arrange fake context for test, to simulate situation where `myFieldset`
         // is a single object instead of an array of objects
-        const context = Object.assign({}, defaultContext)
+        const context = cloner.deep.copy(defaultContext)
         const data = { field1: 'abc', field2: 'def' }
         context.frigForm.data.some_fieldset = data
 
@@ -154,7 +155,7 @@ describe('<Fieldset />', () => {
       it('if frigForm.data.myFieldset is undefined, return empty array', () => {
         // rewrite context so that instead of data.some_fieldset
         // is undefined
-        const context = Object.assign({}, defaultContext)
+        const context = cloner.deep.copy(defaultContext)
         delete context.frigForm.data.some_fieldset
 
         const modifications = td.function('modifications')

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -51,7 +51,7 @@ const mockNestedForm = (replaceFunctions) =>
     render() { return <div /> }
   }
 
-const mountFieldset = (context = defaultContext, props = defaultProps) => {
+const getFieldsetInstance = (context = defaultContext, props = defaultProps) => {
   const opts = { context }
   const wrapper = mount(<Fieldset {...props} />, opts)
   return wrapper.instance()
@@ -65,7 +65,7 @@ describe('<Fieldset />', () => {
       const props = Object.assign({}, defaultProps, {
         FieldsetNestedForm,
       })
-      const instance = mountFieldset(context, props)
+      const instance = getFieldsetInstance(context, props)
       assertionCallback(instance)
     }
 
@@ -203,7 +203,7 @@ describe('<Fieldset />', () => {
   describe('Private Functions', () => {
     describe('_contextAtIndex', () => {
       const testContextAtIndex = (context, expected, keys = ['errors']) => {
-        const instance = mountFieldset(context)
+        const instance = getFieldsetInstance(context)
         const assertion = instance._contextAtIndex(0, keys)
         expect(assertion).to.deep.equal(expected)
       }
@@ -262,7 +262,7 @@ describe('<Fieldset />', () => {
         context.frigForm.requestChildComponentChange = requestChildComponentChange
 
         // mount component
-        instance = mountFieldset(context)
+        instance = getFieldsetInstance(context)
       })
 
       it('returns a new array of the children change', () => {

--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, afterEach */
 
 import React from 'react'
 import { expect } from 'chai'
@@ -51,6 +51,8 @@ const mockNestedForm = (replaceFunctions) =>
   }
 
 describe('<Fieldset />', () => {
+  afterEach(() => { td.reset() })
+
   describe('Public Functions', () => {
     const testPublicFunction = (FieldsetNestedForm, assertionCallback, context = defaultContext) => {  // eslint-disable-line max-len
       const props = Object.assign({}, defaultProps, {

--- a/test/components/form.test.js
+++ b/test/components/form.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, afterEach */
 
 import React from 'react'
 import { expect } from 'chai'
@@ -7,6 +7,8 @@ import { mount } from 'enzyme'
 import td from 'testdouble'
 
 describe('<Form />', () => {
+  afterEach(() => { td.reset() })
+
   // Despite eslint's pleadings, this can't be a stateless function
   // because <Form /> will tack a `ref` on to it, which is illegal.
   class ThemedForm extends React.Component { // eslint-disable-line react/prefer-stateless-function

--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -76,7 +76,7 @@ describe('<Input />', () => {
       })
 
       // set context
-      const context = Object.assign({}, defaultContext)
+      const context = cloner.deep.copy(defaultContext)
       context.frigForm.requestChildComponentChange = requestChildComponentChange
 
       // mount component

--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, afterEach */
 
 import React from 'react'
 import { expect } from 'chai'
@@ -41,6 +41,8 @@ const defaultProps = {
 }
 
 describe('<Input />', () => {
+  afterEach(() => { td.reset() })
+
   it('renders an <UnboundInput> with the correct props', () => {
     const opts = { context: defaultContext }
     const wrapper = mount(<Input {...defaultProps} />, opts)
@@ -55,28 +57,37 @@ describe('<Input />', () => {
   })
 
   describe('_onChange', () => {
-    // test doubles
-    const requestChildComponentChange = td.function.call(null)
-    const onChange = td.function.call(null)
-    const onValidChange = td.function.call(null)
+    let requestChildComponentChange
+    let onChange
+    let onValidChange
+    let input
 
-    // set props
-    const props = Object.assign({}, defaultProps, {
-      onChange,
-      onValidChange,
+    beforeEach(() => {
+      // test doubles
+      requestChildComponentChange = td.function()
+      onChange = td.function('onChange')
+      onValidChange = td.function()
+
+      // set props
+      const props = Object.assign({}, defaultProps, {
+        onChange,
+        onValidChange,
+      })
+
+      // set context
+      const context = Object.assign({}, defaultContext)
+      context.frigForm.requestChildComponentChange = requestChildComponentChange
+
+      // mount component
+      const opts = { context }
+      const wrapper = mount(<Input {...props} />, opts)
+
+      // act
+      input = wrapper.instance()
+      input._onChange('some_new_value', false)
+
+      // console.log(td.explain(requestChildComponentChange))
     })
-
-    // set context
-    const context = Object.assign({}, defaultContext)
-    context.frigForm.requestChildComponentChange = requestChildComponentChange
-
-    // mount component
-    const opts = { context }
-    const wrapper = mount(<Input {...props} />, opts)
-
-    // act
-    const input = wrapper.instance()
-    input._onChange('some_new_value', false)
 
     // assert
     it('when fired, calls requestChildComponentChange (private API)', () => {
@@ -89,10 +100,9 @@ describe('<Input />', () => {
       td.verify(onValidChange(), { times: 0 })
     })
 
-    // act... again :-1:
-    input._onChange('some_new_value', true)
-
     it('when fired, does call onValidChange when valid (public API)', () => {
+      // act... again
+      input._onChange('some_new_value', true)
       td.verify(onValidChange('some_new_value', true))
     })
   })

--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import Input from '../../src/components/input'
 import { mount } from 'enzyme'
 import td from 'testdouble'
+import cloner from 'cloner'
 
 const Stub = () => <div />
 const defaultContext = {
@@ -104,6 +105,34 @@ describe('<Input />', () => {
       // act... again
       input._onChange('some_new_value', true)
       td.verify(onValidChange('some_new_value', true))
+    })
+  })
+
+  describe('React Lifecycle (Mount & Unmount)', () => {
+    it('Add & remove child component In context.frigForm', () => {
+      // test doubles
+      const childComponentWillMount = td.function()
+      const childComponentWillUnmount = td.function()
+
+      // set context
+      const context = cloner.deep.copy(defaultContext)
+      context.frigForm.childComponentWillMount = childComponentWillMount
+      context.frigForm.childComponentWillUnmount = childComponentWillUnmount
+
+      const opts = { context }
+
+      // mount
+      const wrapper = mount(<Input {...defaultProps} />, opts)
+      const instance = wrapper.instance()
+
+      // verify that the child component has mounted
+      td.verify(childComponentWillMount('some_input', instance))
+
+      // unmount
+      wrapper.unmount()
+
+      // verify that the child component has unmounted
+      td.verify(childComponentWillUnmount('some_input', instance))
     })
   })
 })

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, afterEach */
 
 import React from 'react'
 import { expect } from 'chai'
@@ -40,6 +40,8 @@ const defaultProps = {
 }
 
 describe('<UnboundInput />', () => {
+  afterEach(() => { td.reset() })
+
   describe('public methods except validate', () => {
     let wrapper
     let instance


### PR DESCRIPTION
- Add Test for Fieldset
- Add package cloner for deeper cloning because Object.assign only refer to [How To Copy Objects In Javascript](https://www.webreflection.co.uk/blog/2015/10/06/how-to-copy-objects-in-javascript) for more information
- Add test for React Lifecycle because in Fieldset and Input they use those to add and remove their child components when mounting and unmounting