### PR TITLE
Fix htmlInputType for string

### DIFF
--- a/src/type_mapping.js
+++ b/src/type_mapping.js
@@ -1,5 +1,5 @@
 module.exports = {
-  string: { component: 'Input', htmlInputType: 'string' },
+  string: { component: 'Input', htmlInputType: 'text' },
   password: { component: 'Input', htmlInputType: 'password' },
   email: { component: 'Input', htmlInputType: 'email' },
   url: { component: 'Input', htmlInputType: 'url' },


### PR DESCRIPTION
Fixes Frig's `<Input type="string" />` to output `<input type="text" />`

Currently it outputs `<input type="string">`, but HTML inputs do not support type `string` (it just falls back to text since it's an unrecognized type).
