### PR TITLE
Add Object.freeze to all constant test objects ...

### DIFF
--- a/test/components/fieldset.test.js
+++ b/test/components/fieldset.test.js
@@ -28,11 +28,13 @@ const defaultContext = {
     childComponentWillUnmount: () => {},
   },
 }
+Object.freeze(defaultContext)
 
 const defaultProps = {
   name: 'some_fieldset',
   children: Stub,
 }
+Object.freeze(defaultProps)
 
 // This mock is necessary because <Fieldset> renders <FieldsetNestedForm>
 // and calls some of its functions. This mock lets us change the behavior

--- a/test/components/fieldset_text.test.js
+++ b/test/components/fieldset_text.test.js
@@ -10,6 +10,7 @@ const defaultContext = {
     index: 1,
   },
 }
+Object.freeze(defaultContext)
 
 const defaultProps = {
   text: (index) => `Testing ${index}`,

--- a/test/components/form.test.js
+++ b/test/components/form.test.js
@@ -24,6 +24,8 @@ describe('<Form />', () => {
     layout: 'horizontal',
     align: 'right',
   }
+  Object.freeze(formProps)
+
   const form = (
     <Form {...formProps} >
       <div>child</div>

--- a/test/components/form_error_list.test.js
+++ b/test/components/form_error_list.test.js
@@ -17,9 +17,13 @@ describe('<FormErrorList />', () => {
       errors,
     },
   }
+  Object.freeze(context)
+
   const childContextTypes = {
     frigForm: React.PropTypes.object.isRequired,
   }
+  Object.freeze(childContextTypes)
+
   const opts = { context, childContextTypes }
   const wrapper = mount(<FormErrorList />, opts)
   const stub = wrapper.find(Stub)

--- a/test/components/input.test.js
+++ b/test/components/input.test.js
@@ -35,11 +35,13 @@ const defaultContext = {
     childComponentWillUnmount: () => {},
   },
 }
+Object.freeze(defaultContext)
 
 const defaultProps = {
   name: 'some_input',
   type: 'string',
 }
+Object.freeze(defaultProps)
 
 describe('<Input />', () => {
   afterEach(() => { td.reset() })

--- a/test/components/submit.test.js
+++ b/test/components/submit.test.js
@@ -18,6 +18,7 @@ const defaultContext = {
     saved: {},
   },
 }
+Object.freeze(defaultContext)
 
 describe('<Submit />', () => {
   const opts = { context: defaultContext }

--- a/test/components/unbound_input.test.js
+++ b/test/components/unbound_input.test.js
@@ -29,15 +29,18 @@ const defaultContext = {
     align: 'some_align',
   },
 }
+Object.freeze(defaultContext)
 
 const defaultChildContextTypes = {
   frigForm: React.PropTypes.object.isRequired,
 }
+Object.freeze(defaultChildContextTypes)
 
 const defaultProps = {
   name: 'some_unbound_input',
   type: 'string',
 }
+Object.freeze(defaultProps)
 
 describe('<UnboundInput />', () => {
   afterEach(() => { td.reset() })
@@ -295,8 +298,9 @@ describe('<UnboundInput />', () => {
       describe('_guessInputType', () => {
         const testGuessInputType = (props, expected) => {
           // We don't want the type to always be `string`, let tests decide.
-          delete defaultProps.type
-          const nextProps = Object.assign({}, defaultProps, props)
+          const modifiedDefaultProps = Object.assign({}, defaultProps)
+          delete modifiedDefaultProps.type
+          const nextProps = Object.assign({}, modifiedDefaultProps, props)
           const wrapper = mount(<UnboundInput {...nextProps} />, opts)
           const result = wrapper.instance()._guessInputType()
           expect(result).to.equal(expected)


### PR DESCRIPTION
Fix an issue in tests where a `defaultProps` object got mutated and tests passed by accident.

Also add `Object.freeze` to all `defaultProps` / `defaultContext` / etc. in all tests.