### PR TITLE
Revert "Update eslint to version 3.0.1 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "coveralls": "2.11.9",
     "dirty-chai": "1.2.2",
     "enzyme": "2.4.0",
-    "eslint": "3.0.1",
+    "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-plugin-import": "1.10.2",
     "eslint-plugin-jsx-a11y": "1.5.5",


### PR DESCRIPTION
Reverts frig-js/frig#177

Can't merge #177 until airbnb releases a new ruleset with peerDeps for `eslint@3.x`